### PR TITLE
Simple utility functions to make writing tests much easier

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -285,11 +285,16 @@ export class SparseByteArray extends SparseArray<number> {
   }
 
   toIpsHexString(): string {
-    return toHexString(this.toIpsPatch());
+    return toHexViewString(this.toIpsPatch());
   }
 }
 
-export function toHexString(data: Uint8Array) : string {
+export function toHexString(data: Uint8Array, spacing: boolean = false): string {
+  const spacer = spacing ? " " : "";
+  return [...data].map(x => x.toString(16).padStart(2, "0")).join(spacer);
+}
+
+export function toHexViewString(data: Uint8Array) : string {
   //return Array.from(this.toIpsPatch(), x => x.toString(16).padStart(2, '0'))
   // NOTE: this format is compatible with `xxd -r foo.ips.hex > foo.ips`
   const bytes = [...data];
@@ -300,6 +305,22 @@ export function toHexString(data: Uint8Array) : string {
                     .map(x => x.toString(16).padStart(2, '0'))].join(' '));
   }
   return lines.join('\n');
+}
+
+export function fromHexString(str: string): Uint8Array {
+  str = str.replaceAll(' ', '');
+  if (str.length % 2)
+    str = '0' + str;
+
+  const bytes: number[] = [];
+  for (let offs = 0; offs < str.length; offs += 2)
+    bytes.push(parseInt(str.substring(offs, offs + 2), 16));
+
+  return new Uint8Array(bytes);
+}
+
+export function fromByteString(str: string): Uint8Array {
+  return new Uint8Array([...str].map(x => x.charCodeAt(0)))
 }
 
 // deno-lint-ignore no-namespace

--- a/test/util_test.ts
+++ b/test/util_test.ts
@@ -662,7 +662,7 @@ describe('toHexString', function() {
   });
 });
 
-  describe('fromByteString' , function() {
+describe('fromByteString' , function() {
   it('should work', function() {
     expect(fromByteString('ABC123\0\'\"\\\n\r\t\xa9\xff'))
       .toEqual(fromHexString('41 42 43 31 32 33 00 27 22 5C 0A 0D 09 A9 FF'))

--- a/test/util_test.ts
+++ b/test/util_test.ts
@@ -7,7 +7,7 @@
 
 import {describe, it, expect} from 'bun:test';
 import {BitSet, IntervalSet, SparseArray, SparseByteArray,
-        binaryInsert, binarySearch} from '../src/util.ts';
+        binaryInsert, binarySearch, toHexString, fromHexString, fromByteString} from '../src/util.ts';
 import * as util from '../src/util.ts';
 
 const [_] = [util];
@@ -637,5 +637,34 @@ describe('SparseArray', function() {
     it('should return -1 if the bounds are left of the match', function() {
       expect(a.search([2, 3, 4], 0, 3)).toBe(-1);
     });
+  });
+});
+
+describe('fromHexString', function() {
+  const res = [0, 0x40, 0x80, 0xc0, 0xff];
+  it('should work without spaces', function() {
+    expect([...fromHexString('004080c0FF')]).toEqual(res);
+  });
+  it('should work with spaces', function() {
+    expect([...fromHexString(' 0 0408 0c0 FF ')]).toEqual(res);
+  });
+});
+
+describe('toHexString', function() {
+  const spaceHexStr = '00 40 80 c0 ff';
+  const a = fromHexString(spaceHexStr);
+  it('should work without spacing', function() {
+    expect(toHexString(a)).toBe(spaceHexStr.replaceAll(' ', ''));
+  });
+
+  it('should work with spacing', function() {
+    expect(toHexString(a, true)).toBe(spaceHexStr);
+  });
+});
+
+  describe('fromByteString' , function() {
+  it('should work', function() {
+    expect(fromByteString('ABC123\0\'\"\\\n\r\t\xa9\xff'))
+      .toEqual(fromHexString('41 42 43 31 32 33 00 27 22 5C 0A 0D 09 A9 FF'))
   });
 });


### PR DESCRIPTION
Renames toHexString to toHexViewString, as it does more than simply converting to hex.

Also adds:
- toHexString
- fromHexString
- fromByteString. This takes an arbitrary string and interprets it as a string of bytes where all characters are 0-255 (e.g. Python bytes).

Very simple functions, but they will be very convenient in writing tests.