### PR TITLE
Mechanism to support aliases of CS tokens that map to a canonical form

### DIFF
--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -527,7 +527,6 @@ export class Assembler {
         case '.reloc': return this.parseNoArgs(tokens, 1), this.reloc();
         case '.assert': return this.assert(...this.parseAssert(tokens));
         case '.segment': return this.segment(...this.parseSegmentList(tokens, 1, false));
-        case '.byt':
         case '.byte': return this.byte(...this.parseDataList(tokens, true));
         case '.bytestr': return this.byteInternal(this.parseByteStr(tokens));
         case '.res': return this.res(...this.parseResArgs(tokens));

--- a/src/macro.ts
+++ b/src/macro.ts
@@ -31,7 +31,6 @@ export class Macro {
     let next: Token[]|undefined;
     while ((next = await source.next())) {
       if (Tokens.eq(next[0], Tokens.ENDMACRO)) return new Macro(params, lines);
-      if (Tokens.eq(next[0], Tokens.ENDMAC)) return new Macro(params, lines);
       lines.push(next);
     }
     throw new Error(`EOF looking for .endmacro: ${Tokens.nameAt(line[1])}`);

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -210,7 +210,6 @@ export class Preprocessor implements Tokens.Source {
       case '.concat': return this.parseArgs(line, i, 0, this.concat);
       case '.sprintf': return this.parseArgs(line, i, 0, this.sprintf);
       case '.cond': return this.parseArgs(line, i, 0, this.cond);
-      case '.def':
       case '.defined':
         return this.parseArgs(line, i, 1, this.defined);
       case '.definedsymbol':
@@ -378,9 +377,7 @@ export class Preprocessor implements Tokens.Source {
     '.else': ([cs]) => badClose('.if', cs),
     '.elseif': ([cs]) => badClose('.if', cs),
     '.endif': ([cs]) => badClose('.if', cs),
-    '.endmac': ([cs]) => badClose('.macro', cs),
     '.endmacro': ([cs]) => badClose('.macro', cs),
-    '.endrep': (line) => this.parseEndRepeat(line),
     '.endrepeat': (line) => this.parseEndRepeat(line),
     '.exitmacro': async ([, a]) => { noGarbage(a); this.stream.exit(); 
       return await Promise.resolve(); },
@@ -461,7 +458,6 @@ export class Preprocessor implements Tokens.Source {
       line = await this.stream.next() ?? fail(`.repeat with no .endrep`);
       if (Tokens.eq(line[0], Tokens.REPEAT)) depth++;
       if (Tokens.eq(line[0], Tokens.ENDREPEAT)) depth--;
-      if (Tokens.eq(line[0], Tokens.ENDREP)) depth--;
       lines.push(line);
     }
     this.repeats.push([lines, times, -1, ident]);

--- a/src/token.ts
+++ b/src/token.ts
@@ -64,7 +64,8 @@ export interface GroupToken {
 }
 export interface StringToken {
   token: StringTok;
-  str: string;
+  str: string; // Canonical form for CS tokens
+  rawStr?: string; // Original possibly aliased form for CS tokens
   source?: SourceInfo;
 }
 export interface NumberToken {
@@ -95,9 +96,7 @@ export const DOT_EOL: Token = {token: 'cs', str: '.eol'};
 export const ELSE: Token = {token: 'cs', str: '.else'};
 export const ELSEIF: Token = {token: 'cs', str: '.elseif'};
 export const ENDIF: Token = {token: 'cs', str: '.endif'};
-export const ENDMAC: Token = {token: 'cs', str: '.endmac'};
 export const ENDMACRO: Token = {token: 'cs', str: '.endmacro'};
-export const ENDREP: Token = {token: 'cs', str: '.endrep'};
 export const ENDREPEAT: Token = {token: 'cs', str: '.endrepeat'};
 export const ENDPROC: Token = {token: 'cs', str: '.endproc'};
 export const ENDSCOPE: Token = {token: 'cs', str: '.endscope'};
@@ -119,6 +118,20 @@ export const COMMA: Token = {token: 'op', str: ','};
 export const STAR: Token = {token: 'op', str: '*'};
 export const IMMEDIATE: Token = {token: 'op', str: '#'};
 export const ASSIGN: Token = {token: 'op', str: '='};
+
+// CS -> CS token alias map
+export const CS_TOKEN_ALIAS_MAP = new Map<string, string>([
+  // NOTE: Only synonymous so long as 16-bit is not supported
+  ['.addr', '.word'],
+  // NOTE: Only synonymous so long as js65's .bankbyte differs from ca65's
+  ['.bank', '.bankbyte'],
+  ['.byt', '.byte'],
+  ['.def', '.defined'],
+  ['.endmac', '.endmacro'],
+  ['.endrep', '.endrepeat'],
+  ['.mac', '.macro'],
+  ['.undef', '.undefine'],
+]);
 
 export function match(left: Token, right: Token): boolean {
   if (left.token !== right.token) return false;
@@ -154,7 +167,7 @@ export function name(arg: Token): string {
       return arg.str;
     case 'cs':
     case 'op':
-      return `${arg.str.toUpperCase()}`;
+      return `${(arg.rawStr ?? arg.str).toUpperCase()}`;
     default:
       assertNever(arg);
   }
@@ -418,7 +431,7 @@ function checkExhaustive(arg: never): never {
 export const TOKENFUNCS = new Set([
   '.blank',
   '.const',
-  '.defined', // .def ?
+  '.defined',
   '.left',
   '.match',
   '.mid',

--- a/src/token.ts
+++ b/src/token.ts
@@ -120,7 +120,7 @@ export const IMMEDIATE: Token = {token: 'op', str: '#'};
 export const ASSIGN: Token = {token: 'op', str: '='};
 
 // CS -> CS token alias map
-export const CS_TOKEN_ALIAS_MAP = new Map<string, string>([
+export const CS_TOKEN_ALIAS_MAP = new Map([
   // NOTE: Only synonymous so long as 16-bit is not supported
   ['.addr', '.word'],
   // NOTE: Only synonymous so long as js65's .bankbyte differs from ca65's
@@ -129,6 +129,7 @@ export const CS_TOKEN_ALIAS_MAP = new Map<string, string>([
   ['.def', '.defined'],
   ['.endmac', '.endmacro'],
   ['.endrep', '.endrepeat'],
+  ['.exitmac', '.exitmacro'],
   ['.mac', '.macro'],
   ['.undef', '.undefine'],
 ]);

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -86,7 +86,7 @@ export class Tokenizer implements Tokens.Source {
         this.buffer.token(/^((::)?[a-z_][a-z0-9_]*)+/i)) {
       return this.strTok('ident');
     }
-    if (this.buffer.token(/^\.[a-z]+/i)) return this.csStrTok();
+    if (this.buffer.token(/^\.[a-z]+/i)) return this.csTok();
     if (this.buffer.token(/^:([+-]\d+|[-+]+|<+rts|>*rts)/)) return this.strTok('ident');
     if (this.buffer.token(/^(:|\++|-+|&&?|\|\|?|[#*/,=~!^]|<[<>=]?|>[>=]?)/)) {
       return this.strTok('op');
@@ -128,7 +128,7 @@ export class Tokenizer implements Tokens.Source {
     return {token, str: this.buffer.group()!};
   }
 
-  private csStrTok(): Token {
+  private csTok(): Token {
     let grp = this.buffer.group()!;
     return {
       token: 'cs', 

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -86,7 +86,7 @@ export class Tokenizer implements Tokens.Source {
         this.buffer.token(/^((::)?[a-z_][a-z0-9_]*)+/i)) {
       return this.strTok('ident');
     }
-    if (this.buffer.token(/^\.[a-z]+/i)) return this.strTok('cs');
+    if (this.buffer.token(/^\.[a-z]+/i)) return this.csStrTok();
     if (this.buffer.token(/^:([+-]\d+|[-+]+|<+rts|>*rts)/)) return this.strTok('ident');
     if (this.buffer.token(/^(:|\++|-+|&&?|\|\|?|[#*/,=~!^]|<[<>=]?|>[>=]?)/)) {
       return this.strTok('op');
@@ -126,6 +126,15 @@ export class Tokenizer implements Tokens.Source {
 
   private strTok(token: Tokens.StringToken['token']): Token {
     return {token, str: this.buffer.group()!};
+  }
+
+  private csStrTok(): Token {
+    let grp = this.buffer.group()!;
+    return {
+      token: 'cs', 
+      str: Tokens.CS_TOKEN_ALIAS_MAP.get(grp) ?? grp,
+      rawStr: grp,
+    };
   }
 
   private tokenizeNum(str: string = this.buffer.group()!): Token {

--- a/test/tokenizer_test.ts
+++ b/test/tokenizer_test.ts
@@ -71,19 +71,19 @@ describe('Tokenizer.line', function() {
       [{token: 'ident', str: 'label'}, Tokens.COLON],
       [{token: 'ident', str: 'lda'},
        {token: 'op', str: '#'}, {token: 'num', num: 0x1f, width: 1}],
-      [{token: 'cs', str: '.org'}, {token: 'num', num: 0x1c, width: 1},
+      [{token: 'cs', str: '.org', rawStr: '.org'}, {token: 'num', num: 0x1c, width: 1},
        {token: 'op', str: ':'}, {token: 'num', num: 0x1234, width: 2}],
-      [{token: 'cs', str: '.ifdef'}, {token: 'ident', str: 'XX'}],
-      [{token: 'cs', str: '.define'}, {token: 'ident', str: 'YY'}],
-      [{token: 'cs', str: '.define'}, {token: 'ident', str: 'YYZ'},
+      [{token: 'cs', str: '.ifdef', rawStr: '.ifdef'}, {token: 'ident', str: 'XX'}],
+      [{token: 'cs', str: '.define', rawStr: '.define'}, {token: 'ident', str: 'YY'}],
+      [{token: 'cs', str: '.define', rawStr: '.define'}, {token: 'ident', str: 'YYZ'},
        {token: 'num', num: 0b10101100, width: 1}],
       [{token: 'ident', str: 'pla'}],
       [{token: 'ident', str: 'sta'},
        {token: 'lp'}, {token: 'num', num: 0x11, width: 1}, {token: 'rp'},
        {token: 'op', str: ','}, {token: 'ident', str: 'y'}],
-      [{token: 'cs', str: '.elseif'}, {token: 'ident', str: 'YY'}],
+      [{token: 'cs', str: '.elseif', rawStr: '.elseif'}, {token: 'ident', str: 'YY'}],
       [{token: 'ident', str: 'pha'}],
-      [{token: 'cs', str: '.endif'}],
+      [{token: 'cs', str: '.endif', rawStr: '.endif'}],
     ]);
   });
 
@@ -118,7 +118,7 @@ describe('Tokenizer.line', function() {
 
   it('should tokenize an .assert', async function() {
     expect(await tokenize('.assert * = $0c:$8000')).toEqual([
-      [{token: 'cs', str: '.assert'}, {token: 'op', str: '*'},
+      [{token: 'cs', str: '.assert', rawStr: '.assert'}, {token: 'op', str: '*'},
        {token: 'op', str: '='}, {token: 'num', num: 0x0c, width: 1},
        {token: 'op', str: ':'}, {token: 'num', num: 0x8000, width: 2}],
     ]);
@@ -199,6 +199,14 @@ describe('Tokenizer.line', function() {
       [{token: 'ident', str: 'bpl'},
        {token: 'ident', str: ':<<rts'}],
     ]);
+  });
+
+  it('should properly translate aliases', async function() {
+    for (const [rawStr, str] of Tokens.CS_TOKEN_ALIAS_MAP) {
+      expect(await tokenize(rawStr), rawStr).toEqual([
+        [{token: 'cs', str, rawStr}]
+      ]);
+    }
   });
 
   it('should fail to parse a bad hex number', function() {


### PR DESCRIPTION
Proposing this new mechanism for review by the powers that be.

Creates a table of CS token aliases that can map one or more token aliases to single canonical forms, e.g. `.mac` is mapped to `.macro`. To ensure error messages show the form of the token originally provided, the optional field rawStr is added to the StringToken type.

This not only implements some missing aliases in js65 but provides a single, simple method for token aliases, rather than the previous chaotic ad hoc approach.

Initially I intended to translate things like `.bitand` to `&` (yes, CS to op token), but then it occurred to me that that could potentially alter evaluation of expressions.