### PR TITLE
Implement .sprintf

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,13 @@
   "homepage": "https://github.com/shicks/js65#readme",
   "devDependencies": {
     "@types/bun": "^1.1.6",
+    "@types/sprintf-js": "^1.1.4",
     "typescript": "^5.2.2",
     "typescript-language-server": "^2.1.0"
   },
   "description": "",
   "dependencies": {
+    "sprintf-js": "^1.1.3",
     "zod": "^3.23.8"
   }
 }

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -483,6 +483,11 @@ export class Assembler {
 
   // Assemble from a list of tokens
   async line(tokens: Token[]) {
+    if (Tokens.eq(tokens[1], Tokens.ASSIGN) || Tokens.eq(tokens[1], Tokens.SET)) {
+      // Skip over any assignments as these were handled in the preprocessor?
+      // TODO: Should the preprocessor remove the tokens?
+      return;
+    }
     this._source = tokens[0].source;
     if (tokens.length < 3 && Tokens.eq(tokens[tokens.length - 1], Tokens.COLON)) {
       this.label(tokens[0]);

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -486,10 +486,6 @@ export class Assembler {
     this._source = tokens[0].source;
     if (tokens.length < 3 && Tokens.eq(tokens[tokens.length - 1], Tokens.COLON)) {
       this.label(tokens[0]);
-    } else if (Tokens.eq(tokens[1], Tokens.ASSIGN)) {
-      this.assign(Tokens.str(tokens[0]), this.parseExpr(tokens, 2));
-    } else if (Tokens.eq(tokens[1], Tokens.SET)) {
-      this.set(Tokens.str(tokens[0]), this.parseExpr(tokens, 2));
     } else if (tokens[0].token === 'cs') {
       this.directive(tokens);
     } else {
@@ -603,6 +599,14 @@ export class Assembler {
     // if (source) symbol.expr.source = source;
     // // Add the label to the current chunk...?
     // // Record the definition, etc...?
+  }
+
+  assignSym(tokens: Token[]) {
+    this.assign(Tokens.str(tokens[0]), this.parseExpr(tokens, 2));
+  }
+
+  setSym(tokens: Token[]) {
+    this.set(Tokens.str(tokens[0]), this.parseExpr(tokens, 2));
   }
 
   assign(ident: string, expr: Expr|number) {

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -293,9 +293,9 @@ export class Preprocessor implements Tokens.Source {
   }
 
   private sprintf(cs: Token, fmtToks: Token[], ..._args: Token[][]) : Token[] {
-    // NOTE: ca65 supports /^%(%|[-+ #0]*\d*(\.\d*)?[diouXxsc])/ but sprintf-js does not support '+ #' and there really isn't any reason to support floating point precision.
+    // NOTE: ca65 supports /^%(%|[-+ #0]*\d*(\.\d*)?[diouXxsc])/ but sprintf-js does not support '+ #'.
     // Also note: ca65 should work with a value assigned to a variable with = but js65 does not.
-    const fmtRe = /^%(%|-?0?\d*[diouXxsc])/;
+    const fmtRe = /^%(%|-?0?\d*(\.\d+)?[diouXxsc])/;
 
     const fmt = Tokens.expectString(fmtToks[0], cs);
     let sprintfFmt = '';

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -5,6 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+import {vsprintf} from 'sprintf-js';
 import {Define} from './define.ts';
 import type { Expr } from './expr.ts';
 import * as Exprs from './expr.ts';
@@ -292,12 +293,52 @@ export class Preprocessor implements Tokens.Source {
   }
 
   private sprintf(cs: Token, fmtToks: Token[], ..._args: Token[][]) : Token[] {
+    // NOTE: ca65 supports /^%(%|[-+ #0]*\d*(\.\d*)?[diouXxsc])/ but sprintf-js does not support '+ #' and there really isn't any reason to support floating point precision.
+    // Also note: ca65 should work with a value assigned to a variable with = but js65 does not.
+    const fmtRe = /^%(%|-?0?\d*[diouXxsc])/;
+
     const fmt = Tokens.expectString(fmtToks[0], cs);
-    Tokens.expectEol(fmtToks[1], 'a single format string');
-    // figure out what placeholders...
-    // TODO - evaluate numeric args as exprs, strings left as is
-    const [_] = [fmt];
-    throw new Error('unimplemented');
+    let sprintfFmt = '';
+    const sprintfArgs: (string | number)[] = [];
+    let prevTok: Token = fmtToks.slice(-1)[0];
+    let offs = 0, argIdx = 0;
+    while (offs < fmt.length) {
+      // Break up the format string by literal text and format spec segments
+      let pctOffs = fmt.indexOf('%', offs);
+      if (pctOffs < 0)
+        pctOffs = fmt.length;
+
+      if (pctOffs != offs) {
+        // Text segment
+        sprintfFmt += fmt.slice(offs, pctOffs);
+        offs = pctOffs;
+      }
+      else {
+        // Format spec
+        const match = fmtRe.exec(fmt.substring(offs));
+        if (!match)
+          throw new Error("invalid format string");
+        
+        const specType = match[0].slice(-1);
+        if (specType != '%') {
+          const argToks = _args[argIdx];
+          let arg: string | number = 0;
+          if (specType == 's')
+            arg = Tokens.expectString(argToks[0], prevTok);
+          else
+            arg = this.evaluateConst(parseOneExpr(argToks, prevTok));
+
+          sprintfArgs.push(arg);
+          argIdx++;
+          prevTok = argToks.slice(-1)[0];
+        }
+
+        sprintfFmt += match[0];
+        offs += match[0].length;
+      }
+    }
+
+    return [{token: 'str', str: vsprintf(sprintfFmt, sprintfArgs), source: cs.source}];
   }
 
   private cond(_cs: Token, ..._args: Token[][]) : Token[] {

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -44,6 +44,8 @@ interface Env {
   constantSymbol(sym: string): boolean;
   referencedSymbol(sym: string): boolean;
   evaluate(expr: Expr): number|undefined;
+  assignSym(line: Token[]): void;
+  setSym(line: Token[]): void;
   // also want methods to apply shunting yard to token list?
   //  - turn it into a json tree...?
 }
@@ -105,6 +107,11 @@ export class Preprocessor implements Tokens.Source {
           if (Tokens.eq(line[1], Tokens.COLON)) {
             yield line.splice(0, 2);
             break;
+          }
+          if (Tokens.eq(line[1], Tokens.ASSIGN)) {
+            this.env.assignSym(line);
+          } else if (Tokens.eq(line[1], Tokens.SET)) {
+            this.env.setSym(line);
           }
           if (!this.tryExpandMacro(line)) yield line;
           return;

--- a/test/preprocessor_test.ts
+++ b/test/preprocessor_test.ts
@@ -395,18 +395,20 @@ describe('Preprocessor', function() {
       
     }
     it('should work with no arguments', async function() {
-      await testSprintf("test", null, "test");
+      await testSprintf('test', null, 'test');
     });
     it('should work with various arguments', async function() {
-      await testSprintf("%%", null, "%");
-      await testSprintf("%s", "test", "test");
-      await testSprintf("%d", -2, "-2");
-      await testSprintf("%-3i", -3, "-3 ");
-      await testSprintf("%o", 40, "50");
-      await testSprintf("%3u", 5, "  5");
-      await testSprintf("%X", 60, "3C");
-      await testSprintf("%06x", 0x7c, "00007c");
-      await testSprintf("%-6c", 0x41, "A     ");
+      await testSprintf('%%', null, '%');
+      await testSprintf('%s', 'test', 'test');
+      await testSprintf('%5s', 'test', ' test');
+      await testSprintf('%1.3s', 'test', 'tes');
+      await testSprintf('%d', -2, '-2');
+      await testSprintf('%-3i', -3, '-3 ');
+      await testSprintf('%o', 40, '50');
+      await testSprintf('%3u', 5, '  5');
+      await testSprintf('%X', 60, '3C');
+      await testSprintf('%06x', 0x7c, '00007c');
+      await testSprintf('%-6c', 0x41, 'A     ');
     });
     it('should work with all the arguments', async function() {
       await test(


### PR DESCRIPTION
For review.

Implements #20 at least partially.

Does NOT support:
- The `#` modifier e.g. "%#5x" (sprintf-js doesn't support it)
- The ` ` modifier e.g. "% 5x" (sprintf-js doesn't support it)
- The `+` modifier e.g. "%+5x" (sprintf-js accepts it but ignores it)
- Constant symbols defined with `=`, as evaluateConst fails for them